### PR TITLE
Fix subtble error in specfile for non-wine-staging builds

### DIFF
--- a/wine/wine-git.spec
+++ b/wine/wine-git.spec
@@ -871,7 +871,9 @@ unset PKG_CONFIG_PATH
 %ifarch %{ix86}
  --with-system-dllpath=%{mingw32_bindir} \
 %endif
-%{?wine_staging: --with-xattr --with-wayland} \
+%if 0%{?wine_staging}
+ --with-xattr --with-wayland \
+%endif
  --disable-tests
 
 %make_build TARGETFLAGS=""


### PR DESCRIPTION
The previous syntax tested for the existence of the `wine_staging` macro, instead of acting like a ternary operator like the RPM .spec docs suggest, leading to the the args being set even when the macro is set to 0.